### PR TITLE
Feature / Limit the number of scores in the feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,11 +29,11 @@ User.create!(
 rng = Random.new
 now = Time.zone.today
 User.all.each do |user|
-  5.times do |i|
+  10.times do |i|
     Score.create!(
       user: user,
       total_score: rng.rand(66..99),
-      played_at: now - 5.days + i.days
+      played_at: now - 10.days + i.days
     )
   end
 end

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -9,6 +9,15 @@ describe Api::ScoresController, type: :request do
     @score1 = create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
     @score2 = create(:score, user: user2, total_score: 99, played_at: '2021-06-20')
     @score3 = create(:score, user: user2, total_score: 68, played_at: '2021-06-13')
+
+    rng = Random.new
+    25.times do |i|
+      Score.create!(
+        user: @user1,
+        total_score: rng.rand(66..99),
+        played_at: 3.years.ago - 25.days + i.days
+      )
+    end
   end
 
   describe 'GET feed' do
@@ -19,12 +28,22 @@ describe Api::ScoresController, type: :request do
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
 
-      expect(scores.size).to eq 3
+      expect(scores.size).to eq 25
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99
       expect(scores[0]['played_at']).to eq '2021-06-20'
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
+    end
+
+    it 'should return only 25 scores' do
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.length).to eq 25
     end
   end
 


### PR DESCRIPTION
Fixes: [Limit the number of scores in the feed](https://github.com/AACraiu/golfr_backend/issues/21)

**Changes**

Updated user_feed function in ScoresController to fetch only 25 records to improve performance. Added tests to make sure the change is working as intended.

**Before**

According to the changes made to the database seed, there are 30 scores stored. We can see in the test that all 30 were returned, thus failing.

<img width="1119" alt="Screenshot 2023-06-19 at 13 36 23" src="https://github.com/AndreiTanaseGG/golfr_backend/assets/134391769/7d953f62-fd60-486d-b872-c386932d4bac">


**After**

As required, only the first 25 scores are fetched instead of all 30.

<img width="1126" alt="Screenshot 2023-06-19 at 13 30 01" src="https://github.com/AndreiTanaseGG/golfr_backend/assets/134391769/246844b8-2b0e-4b8d-b744-aae836e9d4ae">
